### PR TITLE
feat: add .env.example template for API keys and database configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# ==========================================
+#  AI Provider Keys
+# ==========================================
+# Get this from: https://console.groq.com/keys
+GROQ_API_KEY=gsk_your_groq_api_key_here
+
+# Get this from: https://www.enkryptai.com/
+ENKRYPT_API_KEY=your_enkrypt_api_key_here
+ENKRYPT_POLICY_NAME="Customer Support"
+
+# ==========================================
+#  Database & Vector Store
+# ==========================================
+# Options: 'postgres' (Production) or 'sqlite' (Local Dev)
+DB_TYPE=postgres
+
+# Options: 'production' (PGVector) or 'local' (Chroma)
+VECTOR_MODE=production
+
+# Supabase / Postgres Connection String
+# Format: postgresql://[user]:[password]@[host]:[port]/[db]?sslmode=require
+POSTGRES_URL=postgresql://postgres:your_password_here@aws-0-region.pooler.supabase.com:6543/postgres?sslmode=require


### PR DESCRIPTION
I have added the required .env.example template for API keys and database configuration for a new developer to read it with ease.